### PR TITLE
fix bug of duplicated labels and nonarray extension

### DIFF
--- a/lib/labeling/rules.js
+++ b/lib/labeling/rules.js
@@ -1,4 +1,4 @@
-const { eq, sql, inArray } = require("drizzle-orm");
+const { eq, inArray } = require("drizzle-orm");
 const { db } = require("../db/db");
 const {
   rules,
@@ -14,6 +14,7 @@ async function getCodeIsByCodes(clinicalCodes) {
   const systemCodes = clinicalCodes.map(
     (code) => `${code.system}#${code.code}`
   );
+
   const rawResults = await db
     .select()
     .from(full_codes)
@@ -38,40 +39,53 @@ const getFullLabels = (codeIds) =>
     ? db.select().from(full_codes).where(inArray(full_codes.code_id, codeIds))
     : [];
 
+function prepareGroupMap(allMatchedRules) {
+  return allMatchedRules.reduce((groupMap, rule) => {
+    const groupId = rule.rules.group_id;
+    if (!groupMap[groupId]) {
+      groupMap[groupId] = { children: [], metadata: [] };
+    }
+
+    groupMap[groupId].children.push({
+      code_id: rule.rules.code_id,
+      rule_id: rule.rules.id
+    });
+
+    if (rule.metadata) {
+      const metas = Array.isArray(rule.metadata)
+        ? rule.metadata
+        : [rule.metadata];
+      for (const meta of metas) {
+        if (
+          meta &&
+          !groupMap[groupId].metadata.some(
+            (m) => m && m.id === meta.id && m.type === meta.type
+          )
+        ) {
+          groupMap[groupId].metadata.push(meta);
+        }
+      }
+    }
+
+    return groupMap;
+  }, {});
+}
+
 async function getLabels(codes) {
   const initialCodeIds = await getCodeIsByCodes(codes);
-
   const firstTierRules = await getApplicableRulesByCodeIds(initialCodeIds);
-
   const firstTierLabelIds = firstTierRules.map((rule) => rule.rules.group_id);
-
   const secondTierRules = await getApplicableRulesByCodeIds(firstTierLabelIds);
-
   const secondtTierLabelIds = secondTierRules.map(
     (rule) => rule.rules.group_id
   );
-
   const thirdTierRules = await getApplicableRulesByCodeIds(secondtTierLabelIds);
-
   const thirdTierLabelIds = thirdTierRules.map((rule) => rule.rules.group_id);
 
+  // fourth and fifth tiers seem of no use
   const fourthTierRules = await getApplicableRulesByCodeIds(thirdTierLabelIds);
-
   const fourthTierLabelIds = fourthTierRules.map((rule) => rule.rules.group_id);
-
   const fifthTierRules = await getApplicableRulesByCodeIds(fourthTierLabelIds);
-
-  const fifthTierLabelIds = fifthTierRules.map((rule) => rule.rules.group_id);
-
-  const fullLabels = await getFullLabels(
-    [
-      firstTierLabelIds,
-      secondtTierLabelIds,
-      thirdTierLabelIds,
-      fourthTierLabelIds,
-      fifthTierLabelIds
-    ].flat()
-  );
 
   const allMatchedRules = [
     firstTierRules,
@@ -81,65 +95,28 @@ async function getLabels(codes) {
     fifthTierRules
   ].flat();
 
-  return prepareLabels(allMatchedRules, fullLabels);
+  const groupMap = prepareGroupMap(allMatchedRules);
+  return await prepareLabels(groupMap);
 }
 
-function prepareLabels(allMatchedRules, fullLabels) {
-  const fullLabelsMap = fullLabels.reduce(
-    (soFar, thisLabel) => ({ ...soFar, [thisLabel.code_id]: thisLabel }),
-    {}
-  );
+async function prepareLabels(groupMap) {
+  const groupIds = Object.keys(groupMap).map((id) => parseInt(id, 10));
+  const rawLabels = await getFullLabels(groupIds);
 
-  const rulesWithMetadata = combineMetadata(allMatchedRules);
-
-  const fullRules = rulesWithMetadata.map((rule) => ({
-    ...rule,
-    ...fullLabelsMap[rule.rules.group_id]
-  }));
-
-  return fullRules.map((rule) =>
-    pickAttributes(["system", "code", "display", "metadata"], rule, [
-      "system",
-      "code",
-      "display",
-      "extension"
-    ])
-  );
+  return rawLabels.map((label) => {
+    const entry = groupMap[label.code_id] || { metadata: [] };
+    const extensions = (entry.metadata || []).map(fhirMetadata).filter(Boolean);
+    const labelObj = {
+      system: label.system,
+      code: label.code,
+      display: label.display
+    };
+    if (extensions.length) {
+      labelObj.extension = extensions;
+    }
+    return labelObj;
+  });
 }
-
-const combineMetadata = (allMatchedRules) =>
-  Object.values(
-    allMatchedRules.reduce(
-      (sofar, thisOne) =>
-        sofar[thisOne.rules.id]
-          ? {
-              ...sofar,
-              [thisOne.rules.id]: {
-                ...sofar[thisOne.rules.id],
-                metadata: Array.isArray(sofar[thisOne.rules.id].metadata)
-                  ? sofar[thisOne.rules.id].metadata.concat(thisOne.metadata)
-                  : [
-                      fhirMetadata(sofar[thisOne.rules.id].metadata),
-                      fhirMetadata(thisOne.metadata)
-                    ]
-              }
-            }
-          : { ...sofar, [thisOne.rules.id]: thisOne },
-      {}
-    )
-  );
-
-const pickAttribute = (attributeName, base, rule, renameTo) =>
-  rule[attributeName]
-    ? { ...base, [renameTo ? renameTo : attributeName]: rule[attributeName] }
-    : base;
-
-const pickAttributes = (attributeNames, object, renameTos) =>
-  attributeNames.reduce(
-    (prev, current, index) =>
-      pickAttribute(current, prev, object, renameTos[index]),
-    {}
-  );
 
 const fhirMetadata = ({ type, code, system, display }) =>
   type == "why"
@@ -164,5 +141,7 @@ const extension = (url, value, type) =>
 module.exports = {
   getCodeIsByCodes,
   getApplicableRulesByCodeIds,
-  getLabels
+  getLabels,
+  prepareGroupMap,
+  prepareLabels
 };


### PR DESCRIPTION
when I tested the uploaded data, I found the service will return a response like follows:
```
{
  "resourceType": "Bundle",
  "type": "transaction",
  "entry": [
    {
      "fullUrl": "Observation/0196b33f-d63a-7213-96b4-885f58ad9882/$meta-add",
      "resource": {
        "resourceType": "Parameters",
        "parameter": [
          {
            "name": "meta",
            "valueMeta": {
              "security": [
                {
                  "code": "bh_assessment",
                  "display": "Behavioral health assessments"
                },
                {
                  "code": "depression_assessment",
                  "display": "Depression screening instruments"
                },
                {
                  "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
                  "code": "BH",
                  "display": "Behavioral health information sensitivity"
                },
                {
                  "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
                  "code": "BH",
                  "display": "Behavioral health information sensitivity"
                },
                {
                  "system": "http://terminology.hl7.org/CodeSystem/v3-Confidentiality",
                  "code": "R",
                  "display": "Restricted",
                  "extension": {
                    "id": 2,
                    "type": "who",
                    "uri": null,
                    "system": null,
                    "code": null,
                    "display": "LEAP+ Security Labeling Service"
                  }
                }
              ]
            }
          }
        ]
      },
      "request": {
        "method": "POST",
        "url": "Observation/0196b33f-d63a-7213-96b4-885f58ad9882/$meta-add"
      }
    }
  ]
}
```
There are two identical labels and the extension is not an array. 